### PR TITLE
Support KSS comments in nested SCSS trees

### DIFF
--- a/test/fixtures/scss/nested.scss
+++ b/test/fixtures/scss/nested.scss
@@ -1,0 +1,12 @@
+// Your standard form element.
+//
+// Styleguide 3.0.0
+form {
+
+  // Your standard text input box.
+  //
+  // Styleguide 3.0.1
+  input[type="text"] {
+    border: 1px solid #ccc;
+  }
+}

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -68,4 +68,9 @@ comment
       Kss::Parser.clean_comments(@indented_css_comment)
   end
 
+  test "parses nested SCSS documents" do
+    assert_equal "Your standard form element.", @scss_parsed.section('3.0.0').description
+    assert_equal "Your standard text input box.", @scss_parsed.section('3.0.1').description
+  end
+
 end


### PR DESCRIPTION
I have scss documents that look something like:

``` scss
// Your standard form element.
//
// Styleguide 3.0.0
form {

  // Your standard text input box.
  //
  // Styleguide 3.0.1
  input[type="text"] {
    border: 1px solid #ccc;
  }
}
```

This patch has kss traverse the whole parse tree in the search for KSS documentation.
