### PR TITLE
If the test match is case insensitive, this should be too.

### DIFF
--- a/lib/kss/section.rb
+++ b/lib/kss/section.rb
@@ -37,7 +37,7 @@ module Kss
       comment_sections.each do |text|
         if text =~ /Styleguide \d/i
           cleaned = text.strip.sub(/\.$/, '') # Kill trailing period
-          @section = cleaned.match(/Styleguide (.+)/)[1]
+          @section = cleaned.match(/Styleguide (.+)/i)[1]
         end
       end
 


### PR DESCRIPTION
Otherwise, `StyleGuide` or `styleguide` instead of `Styleguide`  will cause an error.
