### PR TITLE
Include the active state for modifiers within KssStateGenerator

### DIFF
--- a/example/public/javascripts/kss.js
+++ b/example/public/javascripts/kss.js
@@ -3,9 +3,10 @@
   var KssStateGenerator;
   KssStateGenerator = (function() {
     function KssStateGenerator() {
-      var disabled, hover, idx, idxs, rule, stylesheet, _i, _len, _len2, _ref, _ref2;
+      var disabled, hover, active, idx, idxs, rule, stylesheet, _i, _len, _len2, _ref, _ref2;
       hover = /:hover/;
       disabled = /:disabled/;
+      active = /:active/;
       try {
         _ref = document.styleSheets;
         for (_i = 0, _len = _ref.length; _i < _len; _i++) {
@@ -14,7 +15,7 @@
           _ref2 = stylesheet.cssRules;
           for (idx = 0, _len2 = _ref2.length; idx < _len2; idx++) {
             rule = _ref2[idx];
-            if (rule.type === CSSRule.STYLE_RULE && (hover.test(rule.selectorText) || disabled.test(rule.selectorText))) {
+            if (rule.type === CSSRule.STYLE_RULE && (hover.test(rule.selectorText) || disabled.test(rule.selectorText) || active.test(rule.selectorText))) {
               this.insertRule(rule.cssText.replace(':', '.pseudo-class-'));
             }
           }

--- a/lib/kss.coffee
+++ b/lib/kss.coffee
@@ -11,12 +11,13 @@ class KssStateGenerator
   constructor: ->
     hover = /:hover/
     disabled = /:disabled/
+    active = /:active/
 
     try
       for stylesheet in document.styleSheets
         idxs = []
         for rule, idx in stylesheet.cssRules
-          if rule.type is CSSRule.STYLE_RULE and (hover.test(rule.selectorText) or disabled.test(rule.selectorText))
+          if rule.type is CSSRule.STYLE_RULE and (hover.test(rule.selectorText) or disabled.test(rule.selectorText) or active.test(rule.selectorText))
             @insertRule(rule.cssText.replace(':', '.pseudo-class-'))
 
   # Takes a given style and attaches it to the current page.


### PR DESCRIPTION
In my current use of KSS I have modified the Coffeescript to generate the class names for the element's active state that could be useful for others.
