### PR TITLE
LESS.js support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source :rubygems
 
 gem "sass", ">= 3.1"
+gem "less", ">= 2.0"
 
 group :test do
   gem "minitest", ">= 1.5.0"

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -2,3 +2,6 @@ source :rubygems
 
 gem 'sinatra', '~> 1.3.1'
 gem 'kss',     '~> 0.1.1'
+
+
+gem 'less', ">= 2.0"

--- a/kss.gemspec
+++ b/kss.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.files            += Dir.glob("test/**/*")
 
   s.add_dependency   "sass",    ">= 3.1"
+  s.add_dependency   "less",    ">= 2.0"
 
   s.description       = <<desc
   Inspired by TomDoc, KSS attempts to provide a methodology for writing

--- a/lib/kss.rb
+++ b/lib/kss.rb
@@ -1,4 +1,6 @@
 require 'sass'
+require 'v8'
+require 'less'
 
 require 'kss/modifier'
 require 'kss/parser'

--- a/test/fixtures/less/_label.less
+++ b/test/fixtures/less/_label.less
@@ -1,0 +1,10 @@
+/*
+A default form label
+
+Styleguide 5.0.0
+*/
+label {
+  display: block;
+  float: left;  
+  width: 150px;
+}

--- a/test/fixtures/less/buttons.less
+++ b/test/fixtures/less/buttons.less
@@ -1,0 +1,51 @@
+/*
+Your standard form button.
+
+:hover    - Highlights when hovering.
+:disabled - Dims the button when disabled.
+.primary  - Indicates button is the primary action.
+.smaller  - A little bit smaller now.
+ 
+Styleguide 2.1.1.
+*/
+button, .button {
+  padding:5px 15px;
+
+  &.primary, &.primary:hover{
+    color:#fff;
+  }
+
+  &.smaller{
+    font-size:9px;
+  }
+
+  &:hover{
+    color:#337797;
+  }
+
+  &:disabled{
+    opacity:0.5;
+  }
+}
+
+/*
+A button suitable for giving stars to someone.
+ 
+.star-given - A highlight indicating you've already given a star.
+.disabled   - Dims the button to indicate it cannot be used.
+
+Styleguide 2.2.1.
+*/
+a.button.star{
+  display:inline-block;
+
+  .star{ font-size:10px; }
+
+  &.star-given{
+    color:#ae7e00;
+  }
+
+  &.disabled{
+    opacity:0.5;
+  }
+}

--- a/test/fixtures/less/mixins.less
+++ b/test/fixtures/less/mixins.less
@@ -1,0 +1,8 @@
+/*
+Your standard grid helper.
+
+Styleguide 4.0.0.
+*/
+.grid(@columns, @max: 10) {
+  width: (@columns / @max) * 960px;
+}

--- a/test/fixtures/less/nested.less
+++ b/test/fixtures/less/nested.less
@@ -1,0 +1,17 @@
+@import "_label";
+/*
+Your standard form element.
+
+Styleguide 3.0.0
+*/
+form {
+
+  /*
+  Your standard text input box.
+
+  Styleguide 3.0.1
+  */
+  input[type="text"] {
+    border: 1px solid #ccc;
+  }
+}

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -5,6 +5,7 @@ class ParserTest < Kss::Test
   def setup
     @scss_parsed = Kss::Parser.new('test/fixtures/scss')
     @css_parsed = Kss::Parser.new('test/fixtures/css')
+    @less_parsed = Kss::Parser.new('test/fixtures/less')
 
     @css_comment = <<comment
 /*
@@ -54,6 +55,11 @@ comment
       @scss_parsed.section('2.1.1').description
   end
 
+  test "parsers KSS comments in LESS" do
+    assert_equal 'Your standard form button.',
+      @less_parsed.section('2.1.1').description
+  end
+
   test "parses KSS comments in CSS" do
     assert_equal 'Your standard form button.',
       @css_parsed.section('2.1.1').description
@@ -71,6 +77,11 @@ comment
   test "parses nested SCSS documents" do
     assert_equal "Your standard form element.", @scss_parsed.section('3.0.0').description
     assert_equal "Your standard text input box.", @scss_parsed.section('3.0.1').description
+  end
+
+  test "parses nested LESS documents" do
+    assert_equal "Your standard form element.", @less_parsed.section('3.0.0').description
+    assert_equal "Your standard text input box.", @less_parsed.section('3.0.1').description
   end
 
 end


### PR DESCRIPTION
This pull request contains code that
- adds the [less](https://github.com/cowboyd/less.rb) gem as a dependency
- update `Kss::Parser` to work with **LESS** files
- add tests to make sure Styleguides can be extracted from **LESS**

**Caveats**: Since I read the issue on SASS (kneath/kss#18) comments, this code will only parse the _loud_ comments in multiline style /\* … */

Since the real Javascript `less.tree` object is not publicly accessible I had to fallback to 

``` ruby
Less.instance_variable_get "@less"
```

and some evil type comparisons

``` javascript
node instanceof less.tree.Comment
```

 to find out whether a rule is a comment node.

If anyone can help out with a better solution I'll be glad to replace the existing code!
