### PR TITLE
Preserve relative paths to base in file names

### DIFF
--- a/lib/kss/parser.rb
+++ b/lib/kss/parser.rb
@@ -1,3 +1,5 @@
+require 'pathname'
+
 module Kss
   # Public: The main KSS parser. Takes a directory full of SASS / SCSS / CSS
   # files and parses the KSS within them.
@@ -12,6 +14,7 @@ module Kss
     #
     # base_path - The path String where style files are located.
     def initialize(base_path)
+      @base_path = Pathname.new(base_path)
       @sections = {}
 
       Dir["#{base_path}/**/*.*"].each do |filename|
@@ -23,7 +26,7 @@ module Kss
     end
 
     def add_section comment_text, filename
-      base_name = File.basename(filename)
+      base_name = Pathname.new(filename).relative_path_from(@base_path).to_s
       section = Section.new(comment_text, base_name)
       @sections[section.section] = section
     end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -7,6 +7,7 @@ class ParserTest < Kss::Test
     @sass_parsed = Kss::Parser.new('test/fixtures/sass')
     @css_parsed = Kss::Parser.new('test/fixtures/css')
     @less_parsed = Kss::Parser.new('test/fixtures/less')
+    @all = Kss::Parser.new('test/fixtures')
 
     @css_comment = <<comment
 /*
@@ -98,6 +99,10 @@ comment
   test "parses nested SASS documents" do
     assert_equal "Your standard form element.", @sass_parsed.section('3.0.0').description
     assert_equal "Your standard text input box.", @sass_parsed.section('3.0.1').description
+  end
+
+  test "handles paths in file names" do
+    assert_equal "less/mixins.less", @all.section('4.0.0').filename
   end
 
   test "public sections returns hash of sections" do


### PR DESCRIPTION
Changed `Section#filename` to return relative path to base directory. This makes sense when you have CSS files in nested directories and some may even have the same "base name". Also, it's a lot easier to link to GitHub repo in the generated docs if you know the full relative path.
