### PR TITLE
Includes HTML preview at the end of each styleguide block

### DIFF
--- a/example/app.rb
+++ b/example/app.rb
@@ -17,6 +17,7 @@ helpers do
   def styleguide_block(section, &block)
     @section = @styleguide.section(section)
     @example_html = capture{ block.call }
+    @escaped_html = ERB::Util.html_escape @example_html
     @_out_buf << erb(:_styleguide_block)
   end
 

--- a/example/public/stylesheets/layout.css
+++ b/example/public/stylesheets/layout.css
@@ -136,5 +136,8 @@ h1.styleguide {
       font-size: 12px;
       font-weight: normal;
       color: #222; }
+  .styleguide-example > .styleguide-code {
+    font-family: Monaco, monospace;
+  }
 
 /* @end */

--- a/example/views/_styleguide_block.erb
+++ b/example/views/_styleguide_block.erb
@@ -20,5 +20,6 @@
       <%= @example_html.sub('$modifier_class', " #{modifier.class_name}") %>
     </div>
   <% end %>
+  <pre class="styleguide-code"><%= @escaped_html %></pre>
 
 </div>


### PR DESCRIPTION
Changes the sinatra example app to include preview HTML at the bottom of each styleguide block. This demonstrates the intended markup for each block, which can be more convenient than the browser DOM inspector to examine it.
