### PR TITLE
Adds styleguide-html wrapper around example code

### DIFF
--- a/example/views/_styleguide_block.erb
+++ b/example/views/_styleguide_block.erb
@@ -20,6 +20,8 @@
       <%= @example_html.sub('$modifier_class', " #{modifier.class_name}") %>
     </div>
   <% end %>
-  <pre class="styleguide-code"><%= @escaped_html %></pre>
+  <div class="styleguide-html">
+    <pre class="styleguide-code"><%= @escaped_html %></pre>
+  </div>
 
 </div>


### PR DESCRIPTION
The _styleguide_block.erb appears to have been missing the
styleguide-html wrapper around the styleguide-code pre element.
The missing wrapper results in the code example being poorly
laid out and visually unappealing.

Adds the wrapper around the element. This corrects the display
and looks more as expected from the example screenshots on
http://warpspire.com/kss/styleguides/
