### PR TITLE
Adds :target to list of supported pseudo classes

### DIFF
--- a/example/public/javascripts/kss.js
+++ b/example/public/javascripts/kss.js
@@ -5,7 +5,7 @@
 
     function KssStateGenerator() {
       var idx, idxs, pseudos, replaceRule, rule, stylesheet, _i, _len, _len2, _ref, _ref2;
-      pseudos = /(\:hover|\:disabled|\:active|\:visited|\:focus)/g;
+      pseudos = /(\:hover|\:disabled|\:active|\:visited|\:focus|\:target)/g;
       try {
         _ref = document.styleSheets;
         for (_i = 0, _len = _ref.length; _i < _len; _i++) {

--- a/lib/kss.coffee
+++ b/lib/kss.coffee
@@ -1,7 +1,7 @@
 # This class scans your stylesheets for pseudo classes, then inserts a new CSS
 # rule with the same properties, but named 'psuedo-class-{{name}}'.
 #
-# Supported pseudo classes: hover, disabled, active, visited, focus.
+# Supported pseudo classes: hover, disabled, active, visited, focus, target.
 #
 # Example:
 #
@@ -9,7 +9,7 @@
 #   => a.pseudo-class-hover{ color:blue; }
 class KssStateGenerator
   constructor: ->
-    pseudos = /(\:hover|\:disabled|\:active|\:visited|\:focus)/g
+    pseudos = /(\:hover|\:disabled|\:active|\:visited|\:focus|\:target)/g
 
     try
       for stylesheet in document.styleSheets


### PR DESCRIPTION
Adds :target to the pseudos variable in the coffee scripts and
compiles the changes to the kss.js file.

Adding :target allows us to show these modifiers in the generated
style guides. Without support, targetted styles cannot be displayed
without user interaction.
