### PR TITLE
Resets lastIndex of pseudos before reuse

### DIFF
--- a/example/public/javascripts/kss.js
+++ b/example/public/javascripts/kss.js
@@ -14,6 +14,7 @@
           _ref2 = stylesheet.cssRules;
           for (idx = 0, _len2 = _ref2.length; idx < _len2; idx++) {
             rule = _ref2[idx];
+            pseudos.lastIndex = 0;
             while ((rule.type === CSSRule.STYLE_RULE) && pseudos.test(rule.selectorText)) {
               replaceRule = function(matched, stuff) {
                 return matched.replace(/\:/g, '.pseudo-class-');

--- a/lib/kss.coffee
+++ b/lib/kss.coffee
@@ -15,6 +15,7 @@ class KssStateGenerator
       for stylesheet in document.styleSheets
         idxs = []
         for rule, idx in stylesheet.cssRules
+          pseudos.lastIndex = 0
           while (rule.type == CSSRule.STYLE_RULE) && pseudos.test(rule.selectorText)
             replaceRule = (matched, stuff) ->
               return matched.replace(/\:/g, '.pseudo-class-')


### PR DESCRIPTION
When a regex is used with the g operator in JavaScript, it keeps
track of where the last match was found for future use. When a new
test is ran on that same regex, the pattern continues searching
from the lastIndex which means patterns before the lastIndex are not
used when testing. This can result in strings that should have matched
the regex to be reported as not matching.

Adds a line to reset the lastIndex of pseudos to zero before each
test is ran to make sure all patterns are tested against every single
time.

Additional information about the problem can be found at:

http://blog.stevenlevithan.com/archives/fixing-javascript-regexp
