### PR TITLE
Fix kss.coffee

### DIFF
--- a/lib/kss.coffee
+++ b/lib/kss.coffee
@@ -13,12 +13,13 @@ class KssStateGenerator
 
     try
       for stylesheet in document.styleSheets
-        idxs = []
-        for rule, idx in stylesheet.cssRules
-          while (rule.type == CSSRule.STYLE_RULE) && pseudos.test(rule.selectorText)
-            replaceRule = (matched, stuff) ->
-              return matched.replace(/\:/g, '.pseudo-class-')
-            @insertRule(rule.cssText.replace(pseudos, replaceRule))
+        if stylesheet.href.indexOf(document.domain) >= 0
+          idxs = []
+          for rule, idx in stylesheet.cssRules
+            while (rule.type == CSSRule.STYLE_RULE) && pseudos.test(rule.selectorText)
+              replaceRule = (matched, stuff) ->
+                return matched.replace(/\:/g, '.pseudo-class-')
+              @insertRule(rule.cssText.replace(pseudos, replaceRule))
 
   # Takes a given style and attaches it to the current page.
   #


### PR DESCRIPTION
Only search for pseudo classes in css files coming from the original host.
Else Firefox will fail with a "security exception".
