### PR TITLE
Adds the relative path of a file to the section hash

### DIFF
--- a/lib/kss/parser.rb
+++ b/lib/kss/parser.rb
@@ -2,10 +2,10 @@ module Kss
   # Public: The main KSS parser. Takes a directory full of SASS / SCSS / CSS
   # files and parses the KSS within them.
   class Parser
-    
+
     # Public: Returns a hash of Sections.
     attr_accessor :sections
-    
+
     # Public: Initializes a new parser based on a directory of files. Scans
     # within the directory recursively for any comment blocks that look like
     # KSS.
@@ -25,8 +25,9 @@ module Kss
     end
 
     def add_section comment_text, filename
+      base_path = current_directory_path(File.dirname(filename))
       base_name = File.basename(filename)
-      section = Section.new(comment_text, base_name)
+      section = Section.new(comment_text, base_path, base_name)
       @sections[section.section] = section
     end
 
@@ -46,6 +47,13 @@ module Kss
     # Returns a Section for a reference, or a blank Section if none found.
     def section(reference)
       @sections[reference] || Section.new
+    end
+
+    # Public: Removes current working directory from absolute path
+    #
+    # Returns a string of the current file's relative path
+    def current_directory_path(file)
+      file.gsub(`pwd`.chomp, "")
     end
 
   end

--- a/lib/kss/section.rb
+++ b/lib/kss/section.rb
@@ -11,13 +11,17 @@ module Kss
     # Public: Returns the filename where this section is found.
     attr_reader :filename
 
+    # Public: Returns the filepath of the filename.
+    attr_reader :filepath
+
     # Public: Initialize a new Section
     #
     # comment_text - The raw comment String, minus any comment syntax.
     # filename     - The filename as a String.
-    def initialize(comment_text=nil, filename=nil)
+    def initialize(comment_text=nil, filepath=nil, filename=nil)
       @raw = comment_text
       @filename = filename
+      @filepath = filepath
     end
 
     # Splits up the raw comment text into comment sections that represent
@@ -77,13 +81,13 @@ module Kss
     end
 
   private
-  
+
     def section_comment
       comment_sections.find do |text|
         text =~ /Styleguide \d/i
       end.to_s
     end
-  
+
     def modifiers_comment
       comment_sections[1..-1].reject do |section|
         section == section_comment


### PR DESCRIPTION
So I saw how you guys were linking to a Github file for the stylesheet responsible for each UI element. For clarification;
![Example link](http://cl.ly/image/3E002W0e0Y1w/Screen%20Shot%202013-01-23%20at%2021.32.22.png)

I have my stylesheets separated into different folders so just having the current file's basename wasn't enough. So this PR adds the current file's relative path to the hash so it can be used create part of the file's url on Github. I'm pretty new to Rails let alone Ruby so I'm sure this could be handled better.

Example usage would be to set up a helper method that takes the hash as an argument and return `https://github.com/user/repo/#{arg.filepath}/#{arg.filename}`.
