### PR TITLE
Fix infinite while loop and reset regex in CoffeeScript

### DIFF
--- a/example/public/javascripts/kss.js
+++ b/example/public/javascripts/kss.js
@@ -4,21 +4,24 @@
   KssStateGenerator = (function() {
 
     function KssStateGenerator() {
-      var idx, idxs, pseudos, replaceRule, rule, stylesheet, _i, _len, _len2, _ref, _ref2;
+      var idx, idxs, pseudos, replaceRule, rule, stylesheet, _i, _j, _len, _len1, _ref, _ref1;
       pseudos = /(\:hover|\:disabled|\:active|\:visited|\:focus)/g;
       try {
         _ref = document.styleSheets;
         for (_i = 0, _len = _ref.length; _i < _len; _i++) {
           stylesheet = _ref[_i];
-          idxs = [];
-          _ref2 = stylesheet.cssRules;
-          for (idx = 0, _len2 = _ref2.length; idx < _len2; idx++) {
-            rule = _ref2[idx];
-            while ((rule.type === CSSRule.STYLE_RULE) && pseudos.test(rule.selectorText)) {
-              replaceRule = function(matched, stuff) {
-                return matched.replace(/\:/g, '.pseudo-class-');
-              };
-              this.insertRule(rule.cssText.replace(pseudos, replaceRule));
+          if (stylesheet.href.indexOf(document.domain) >= 0) {
+            idxs = [];
+            _ref1 = stylesheet.cssRules;
+            for (idx = _j = 0, _len1 = _ref1.length; _j < _len1; idx = ++_j) {
+              rule = _ref1[idx];
+              if ((rule.type === CSSRule.STYLE_RULE) && pseudos.test(rule.selectorText)) {
+                replaceRule = function(matched, stuff) {
+                  return matched.replace(/\:/g, '.pseudo-class-');
+                };
+                this.insertRule(rule.cssText.replace(pseudos, replaceRule));
+              }
+              pseudos.lastIndex = 0;
             }
           }
         }

--- a/lib/kss.coffee
+++ b/lib/kss.coffee
@@ -16,10 +16,11 @@ class KssStateGenerator
         if stylesheet.href.indexOf(document.domain) >= 0
           idxs = []
           for rule, idx in stylesheet.cssRules
-            while (rule.type == CSSRule.STYLE_RULE) && pseudos.test(rule.selectorText)
+            if (rule.type == CSSRule.STYLE_RULE) && pseudos.test(rule.selectorText)
               replaceRule = (matched, stuff) ->
                 return matched.replace(/\:/g, '.pseudo-class-')
               @insertRule(rule.cssText.replace(pseudos, replaceRule))
+            pseudos.lastIndex = 0
 
   # Takes a given style and attaches it to the current page.
   #


### PR DESCRIPTION
The while loop that iterates over a single pseudo style is causing webkit browsers to crash as discussed in issues #55 and #48. It seems like this while loop's original purpose was to select a pseudo style missed by the first pass through of the test() regex function. When a regex is used in a loop like this it's lastIndex needs to be reset to zero on each iteration otherwise it will continue from the last match-end position (I experience this issue in Firefox but not Chrome). 

For example, if you just change the `while` loop to an `if` statement like in the pull request in #48 the example Sinatra app won't display the button:disable pseudo element style properly in Firefox because of this issue with `lastIndex`.  Resetting the lastIndex of the regex on each style iteration fixes this issue so this while loop is no longer needed and can be replaced by an if statement. 

See this post for more details about this bug with regex lastIndex: http://blog.stevenlevithan.com/archives/es3-regexes-broken
