### PR TITLE
infinite loop in kss.js

### DIFF
--- a/example/public/javascripts/kss.js
+++ b/example/public/javascripts/kss.js
@@ -6,6 +6,9 @@
     function KssStateGenerator() {
       var idx, idxs, pseudos, replaceRule, rule, stylesheet, _i, _len, _len2, _ref, _ref2;
       pseudos = /(\:hover|\:disabled|\:active|\:visited|\:focus)/g;
+      replaceRule = function(matched) {
+        return matched.replace(/\:/, '.pseudo-class-');
+      };
       try {
         _ref = document.styleSheets;
         for (_i = 0, _len = _ref.length; _i < _len; _i++) {
@@ -14,10 +17,7 @@
           _ref2 = stylesheet.cssRules;
           for (idx = 0, _len2 = _ref2.length; idx < _len2; idx++) {
             rule = _ref2[idx];
-            while ((rule.type === CSSRule.STYLE_RULE) && pseudos.test(rule.selectorText)) {
-              replaceRule = function(matched, stuff) {
-                return matched.replace(/\:/g, '.pseudo-class-');
-              };
+            if ((rule.type === CSSRule.STYLE_RULE) && rule.selectorText.match(pseudos)) {
               this.insertRule(rule.cssText.replace(pseudos, replaceRule));
             }
           }


### PR DESCRIPTION
The main trouble is here:
            while ((rule.type === CSSRule.STYLE_RULE) && pseudos.test(rule.selectorText)) {
              replaceRule = function(matched, stuff) {
                return matched.replace(/:/g, '.pseudo-class-');
              };
              this.insertRule(rule.cssText.replace(pseudos, replaceRule));
            }

'While' cycle checking, does 'rule.selectorText' matches somehow with 'pseudos'.
And if it does, than add 'rule.cssText.replace(pseudos, replaceRule)' to 'this'.

The problem is that .replace() does not change rule.cssText, it returns new string with changes.
In that case, on the next iteration 'while' will check the same stuff.
In Chrome it leads to infinite loop.
Actually, i do not know why FF works good. it might be break infinite loops.

I also placed replaceRule higher in code, for not to create new function many times.
Also, we do not need g key in small regex inside replaceRule function, because 'matched' value contains only one matching.
I have tested some small examples about replace and g-key here http://jsbin.com/ukizup/2/edit

And the last thing, -- pseudos.test(rule.selectorText).
I have not run an example on ruby realization of KSS, bkz i enjoy js. 
So i am working with https://github.com/jesseditson/jss, wich uses the same example as you do, includes kss.js client-side file.
And i do not know why, but running current example in FF, .test() function works strange. 
It returns false when checking :disabled.
With other .css it might return false on other pseudo class rule, but as i could see, problems arise when there are several consecutive pseudo class selectors in .css
I can not find the reason of this issue, so i replaced .test() with .match(), which do almost the same stuff in this situation, but works good for me. 
