### PR TITLE
Permit words for use as section keys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ a.button.star.disabled{
 }
 ```
 
+KSS can also support words as Styleguide section names
+```scss
+// Styleguide Forms.Checkboxes.
+// - or -
+// Styleguide Forms - Special Checkboxes.
+```
+
 ## Ruby Library [![Build Status](https://travis-ci.org/kneath/kss.png)](https://travis-ci.org/kneath/kss)
 
 This repository includes a ruby library suitable for parsing SASS, SCSS, and CSS documented with KSS guidelines. To use the library, include it in your project as a gem from <https://rubygems.org/gems/kss>. Then, create a parser and explore your KSS.

--- a/SPEC.md
+++ b/SPEC.md
@@ -109,7 +109,19 @@ If the UI element you are documenting has an example in the styleguide, you shou
 // Styleguide 2.1.3.
 ```
 
-References should be integer sections separated by periods. Each period denotes a hierarchy of the styleguide. Styleguide references can point to entire sections, a portion of the section, or a specific example.
+References can be integer sections separated by periods. Each period denotes a hierarchy of the styleguide. Styleguide references can point to entire sections, a portion of the section, or a specific example.
+
+References may also be period seperated word keys.  Leading words denote hierarchy.
+
+```scss
+// Styleguide Forms.Checkboxes.
+```
+
+Finally, references may be more readable word phrases.
+
+```scss
+// Styleguide Forms - Special Checkboxes
+```
 
 If there is no example, then you must note that there is no reference.
 

--- a/lib/kss/parser.rb
+++ b/lib/kss/parser.rb
@@ -2,7 +2,8 @@ module Kss
   # Public: The main KSS parser. Takes a directory full of SASS / SCSS / CSS
   # files and parses the KSS within them.
   class Parser
-    
+    STYLEGUIDE_PATTERN = (/Styleguide [[:alnum:]]/i).freeze
+
     # Public: Returns a hash of Sections.
     attr_accessor :sections
     
@@ -38,7 +39,7 @@ module Kss
       return false unless cleaned_comment.is_a? String
 
       possible_reference = cleaned_comment.split("\n\n").last
-      possible_reference =~ /Styleguide \d/
+      possible_reference =~ STYLEGUIDE_PATTERN
     end
 
     # Public: Finds the Section for a given styleguide reference.

--- a/lib/kss/section.rb
+++ b/lib/kss/section.rb
@@ -80,7 +80,7 @@ module Kss
   
     def section_comment
       comment_sections.find do |text|
-        text =~ /Styleguide \d/i
+        text =~ Parser::STYLEGUIDE_PATTERN
       end.to_s
     end
   

--- a/test/fixtures/css/buttons.css
+++ b/test/fixtures/css/buttons.css
@@ -36,3 +36,25 @@ a.button.star {
     color: #ae7e00; }
   a.button.star.disabled {
     opacity: 0.5; }
+
+/*
+A big button
+
+.really-big - Even bigger button
+
+Styleguide Buttons.Big.
+*/
+a.button.big {
+  display: inline-block;
+  font-size: 10em; }
+  a.button.big.really-big {
+    font-size: 20em; }
+
+/*
+A button truly lime in color
+
+Styleguide Buttons - Truly Lime
+*/
+a.button.lime {
+  color: lime;
+}

--- a/test/fixtures/less/buttons.less
+++ b/test/fixtures/less/buttons.less
@@ -49,3 +49,19 @@ a.button.star{
     opacity:0.5;
   }
 }
+
+/*
+A big button
+
+.really-big - Even bigger button
+
+Styleguide Buttons.Big.
+*/
+a.button.big {
+  display: inline-block;
+  font-size: 10em;
+
+  .really-big {
+    font-size: 20em;
+  }
+}

--- a/test/fixtures/sass/buttons.sass
+++ b/test/fixtures/sass/buttons.sass
@@ -38,3 +38,15 @@ a.button.star
 
   &.disabled
     opacity: 0.5
+
+// A big button
+//
+// .really-big - A really big button
+//
+// Styleguide Buttons.Big.
+a.button.big
+  display: inline-block;
+  font-size: 10em;
+
+  &.really-big
+    font-size: 20em;

--- a/test/fixtures/scss/buttons.scss
+++ b/test/fixtures/scss/buttons.scss
@@ -45,3 +45,17 @@ a.button.star{
     opacity:0.5;
   }
 }
+
+// A big button
+//
+// .really-big - Even bigger button
+//
+// Styleguide Buttons.Big.
+a.button.big {
+  display: inline-block;
+  font-size: 10em;
+
+  &.really-big {
+    font-size: 20em;
+  }
+}

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -66,9 +66,19 @@ comment
       @scss_parsed.section('2.1.1').description
   end
 
+  test "parses KSS keys that are words in SCSS" do
+    assert_equal 'A big button',
+      @scss_parsed.section('Buttons.Big').description
+  end
+
   test "parsers KSS comments in LESS" do
     assert_equal 'Your standard form button.',
       @less_parsed.section('2.1.1').description
+  end
+
+  test "parses KSS keys that are words in LESS" do
+    assert_equal 'A big button',
+      @less_parsed.section('Buttons.Big').description
   end
 
   test "parses KSS multi-line comments in SASS (/* ... */)" do
@@ -81,9 +91,24 @@ comment
       @sass_parsed.section('2.2.1').description
   end
 
+  test "parses KSS keys that are words in in SASS" do
+    assert_equal 'A big button',
+      @sass_parsed.section('Buttons.Big').description
+  end
+
   test "parses KSS comments in CSS" do
     assert_equal 'Your standard form button.',
       @css_parsed.section('2.1.1').description
+  end
+
+  test "parses KSS keys that are words in CSS" do
+    assert_equal 'A big button',
+      @css_parsed.section('Buttons.Big').description
+  end
+
+  test "parses KSS keys that word phases in CSS" do
+    assert_equal 'A button truly lime in color',
+      @css_parsed.section('Buttons - Truly Lime').description
   end
 
   test "parses nested SCSS documents" do
@@ -102,11 +127,11 @@ comment
   end
 
   test "public sections returns hash of sections" do
-    assert_equal 2, @css_parsed.sections.count
+    assert_equal 4, @css_parsed.sections.count
   end
 
   test "parse multiple paths" do
-    assert_equal 6, @multiple_parsed.sections.count
+    assert_equal 7, @multiple_parsed.sections.count
   end
 
 end

--- a/test/section_test.rb
+++ b/test/section_test.rb
@@ -39,4 +39,10 @@ comment
     assert_equal '2.1.1', @section.section
   end
 
+  test "parses word phrases as styleguide references" do
+    @comment_text.gsub!('2.1.1', 'Buttons - Truly Lime')
+    section = Kss::Section.new(@comment_text, 'example.css')
+    assert_equal 'Buttons - Truly Lime', @section.section
+  end
+
 end


### PR DESCRIPTION
This is an experimental idea to allows words for section keys.  So, Forms.Radiobuttons, etc.  You could also mix/match like Forms.1 to isolate numbering changes.

It's possible it should require a flag to KSS parser to enable this mode.

It's also possible this is crazy.  I kind of like the idea because then I think you can reorder (or not sweat the ordering when starting out) without having to edit toplevel numbers every time you shuffle.
