### PR TITLE
Use HTTPS for rubygems.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 group :test do
   gem "minitest", ">= 1.5.0"


### PR DESCRIPTION
This updates the project's gemfile to use HTTPS for rubygems. This change suppresses this warning:

> The source :rubygems is deprecated because HTTP requests are insecure.
> Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
