### PR TITLE
Make sure "No styleguide reference" doesn't blow up.

### DIFF
--- a/lib/kss/parser.rb
+++ b/lib/kss/parser.rb
@@ -2,7 +2,7 @@ module Kss
   # Public: The main KSS parser. Takes a directory full of SASS / SCSS / CSS
   # files and parses the KSS within them.
   class Parser
-    STYLEGUIDE_PATTERN = (/Styleguide [[:alnum:]]/i).freeze
+    STYLEGUIDE_PATTERN = (/(?<!No )Styleguide [[:alnum:]]/i).freeze
 
     # Public: Returns a hash of Sections.
     attr_accessor :sections

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -102,4 +102,16 @@ class ParserTest < Kss::Test
     assert_equal "Your standard text input box.", @sass_parsed.section('3.0.1').description
   end
 
+  test "parse with no styleguide reference comment" do
+    scss_input =<<-'EOS'
+      // Nothing here
+      //
+      // No styleguide reference.
+      input[type="text"] {
+        border: 1px solid #ccc;
+      }
+    EOS
+
+    assert Kss::Parser.new(scss_input)
+  end
 end


### PR DESCRIPTION
Add a test and modify the styleguide comment parsing regex.
