### PR TITLE
Assertion on incorrect object in parser_test.rb

### DIFF
--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -99,7 +99,7 @@ class ParserTest < Kss::Test
     }
     EOS
     assert_equal "Your standard form element.", Kss::Parser.new(scss_input).section('3.0.0').description
-    assert_equal "Your standard text input box.", @sass_parsed.section('3.0.1').description
+    assert_equal "Your standard text input box.", Kss::Parser.new(scss_input).section('3.0.1').description
   end
 
   test "parse with no styleguide reference comment" do


### PR DESCRIPTION
In the parse_from_string test, the assertion is made on the @sass_parsed instance, whereas it ought to be on the newly created parser instance.
