### PR TITLE
Fix multiline modifier descriptions on indent

### DIFF
--- a/lib/kss/section.rb
+++ b/lib/kss/section.rb
@@ -63,14 +63,13 @@ module Kss
         next if line.strip.empty?
         indent = line.scan(/^\s*/)[0].to_s.size
 
-        if last_indent && indent > last_indent
+        if last_indent && indent >= last_indent
           modifiers.last.description += line.squeeze(" ")
         else
           modifier, desc = line.split(" - ")
           modifiers << Modifier.new(modifier.strip, desc.strip) if modifier && desc
+          last_indent = indent + 1
         end
-
-        last_indent = indent
       end
 
       modifiers

--- a/test/section_test.rb
+++ b/test/section_test.rb
@@ -12,6 +12,8 @@ Your standard form button.
 :disabled - Dims the button when disabled.
 .primary  - Indicates button is the primary action.
 .smaller  - A smaller button
+            for when the action
+            needs less emphasis.
 
 Styleguide 2.1.1.
 comment
@@ -37,6 +39,10 @@ comment
 
   test "parses the styleguide reference" do
     assert_equal '2.1.1', @section.section
+  end
+
+  test "parses a modifier's multiline description" do
+    assert_equal 'A smaller button for when the action needs less emphasis.', @section.modifiers.last.description
   end
 
   test "parses word phrases as styleguide references" do


### PR DESCRIPTION
Hi! I noticed there was support for multi-line modifier descriptions, but it breaks on anything >2 lines.

```
# Form Button

Your standard form button.

:hover    - Highlights when hovering.
:disabled - Dims the button when disabled.
.primary  - Indicates button is the primary action.
.smaller  - A smaller button
            for
            ants.

Styleguide 2.1.1.
```

That is unless you change it to this:

```
.smaller  - A smaller button
            for 
              ants.
```

This should fix the issue for nice indents.
