### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ KSS can also support words as Styleguide section names
 // Styleguide Forms - Special Checkboxes.
 ```
 
-## Ruby Library [![Build Status](https://travis-ci.org/kneath/kss.png)](https://travis-ci.org/kneath/kss) [![Code Climate](https://codeclimate.com/github/kneath/kss.png)](https://codeclimate.com/github/kneath/kss)
-
+## Ruby Library [![Build Status](https://travis-ci.org/kneath/kss.png)](https://travis-ci.org/kneath/kss) [![Code Climate](https://codeclimate.com/github/kneath/kss.png)](https://codeclimate.com/github/kneath/kss) [![Inline docs](http://inch-ci.org/github/kneath/kss.png?branch=master)](http://inch-ci.org/github/kneath/kss)
+ 
 This repository includes a ruby library suitable for parsing SASS, SCSS, and CSS documented with KSS guidelines. To use the library, include it in your project as a gem from <https://rubygems.org/gems/kss>. Then, create a parser and explore your KSS.
 
 ```ruby


### PR DESCRIPTION
Hi there,

this patch adds a docs badge to the README of your CSS documentation tool (which is kind of mind-bending). The idea is to show off inline-documentation of Ruby projects to potential contributors: [![Inline docs](http://inch-ci.org/github/kneath/kss.png)](http://inch-ci.org/github/kneath/kss)

The badge links to [Inch CI](http://inch-ci.org), a project that tries to raise the visibility of inline-docs to encourage aspiring Rubyists to document their code. Your status page is http://inch-ci.org/github/kneath/kss/

Inch CI is still in its infancy, but already used by projects like [Bundler](https://github.com/bundler/bundler), [Guard](https://github.com/guard/guard), [Haml](https://github.com/haml/haml), [Pry](https://github.com/pry/pry), and [ROM](https://github.com/rom-rb/rom).

What do you think?
