### PR TITLE
Update URL to Node.js port of KSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,5 +117,5 @@ I apologize on behalf of the Ruby community for this, it's embarrassing and disa
 
 ## Implementations
 
-The KSS specification has also been implemented in [Python](https://github.com/seanbrant/pykss), [Node.js](https://github.com/hughsk/kss-node), [PHP](https://github.com/scaninc/kss-php) and [Java] (https://github.com/revbingo/kss-java)
+The KSS specification has also been implemented in [Python](https://github.com/seanbrant/pykss), [Node.js](https://github.com/kss-node/kss-node), [PHP](https://github.com/scaninc/kss-php) and [Java] (https://github.com/revbingo/kss-java)
 


### PR DESCRIPTION
The old URL for the Node.js port ( https://github.com/hughsk/kss-node ) has changed because hughsk has agreed to move the project to a kss-node GitHub organization. While the old URL _does_ redirect to the new URL, it would be nice to update the KSS readme with the new URL.
