### PR TITLE
Lots of little tweaks to the spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The methodology and ideas behind Knyle Style Sheets are contained in [SPEC.md](h
 
 ```css
 /*
+Star button
+
 A button suitable for giving stars to someone.
 
 :hover             - Subtle hover highlight.

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ A button suitable for giving stars to someone.
 
 Styleguide 2.1.3
 */
-a.button.star {
+.star-button {
   ...
 }
-a.button.star.stars-given {
+.star-button.stars-given {
   ...
 }
-a.button.star.disabled {
+.star-button.disabled {
   ...
 }
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A button suitable for giving stars to someone.
 .stars-given:hover - Subtle hover highlight on top of stars-given styling.
 .disabled          - Dims the button to indicate it cannot be used.
 
-Styleguide 2.1.3.
+Styleguide 2.1.3
 */
 a.button.star{
   ...

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ A button suitable for giving stars to someone.
 
 Styleguide 2.1.3
 */
-a.button.star{
+a.button.star {
   ...
 }
-a.button.star.stars-given{
+a.button.star.stars-given {
   ...
 }
-a.button.star.disabled{
+a.button.star.disabled {
   ...
 }
 ```

--- a/SPEC.md
+++ b/SPEC.md
@@ -12,11 +12,11 @@ KSS focuses on *how people work with CSS* — it does not define code structures
 
 Unlike TomDoc, not every CSS rule should be documented. You should document a rule declaration when the rule can accurately describe a visual UI element in the style guide. Each element should have one documentation block describing that particular UI element's various states.
 
-KSS documentation is hierarchical in nature — any documentation blocks at any point within the style guide hierarchy apply to the documentation blocks beneath that level. This means that documentation for 2.1 applies to documentation for 2.1.3.
+KSS documentation is hierarchical in nature — any documentation block at any point within the style guide hierarchy applies to the documentation blocks beneath that level. This means that documentation for 2.1 applies to documentation for 2.1.3.
 
 ### Format
 
-The basic format for KSS documentation can be best explained in an example:
+The basic format for KSS documentation can be explained best in an example:
 
 ```css
 /*

--- a/SPEC.md
+++ b/SPEC.md
@@ -27,6 +27,8 @@ The basic format for KSS documentation can be explained best in an example:
 
 ```css
 /*
+Star button
+
 A button suitable for giving stars to someone.
 
 :hover             - Subtle hover highlight.
@@ -50,6 +52,8 @@ Styleguide 2.1.3
 When using a preprocessor that supports the functionality, use `//` to prefix your comment sections (Sass example):
 
 ```scss
+// Star button
+//
 // A button suitable for giving stars to someone.
 //
 // :hover             - Subtle hover highlight.
@@ -69,11 +73,23 @@ When using a preprocessor that supports the functionality, use `//` to prefix yo
 }
 ```
 
-Each KSS documentation block consists of three parts: a description of what the element does or looks like, a list of modifier classes or pseudo-classes and how they modify the element, and a reference to the element's position in the style guide.
+Each KSS documentation block consists of two required parts and a few optional parts:
 
-### The description section
+1. a heading *(required)*
+2. a description of what the style does or looks like *(optional)*
+3. a list of modifier classes or pseudo-classes and how they modify the style *(optional)*
+4. a reference to the style's position in the style guide *(required)*
 
-The description should be plain sentences of what the CSS rule or hierarchy does and looks like. A good description gives guidance toward the application of elements the CSS rules style.
+### The heading and description sections
+
+The description should be plain sentences of what the CSS rule or hierarchy does or looks like. A good description gives guidance toward the application of elements the CSS rules style. The first paragraph in the description will be used as the heading for that style guide section.
+
+```scss
+// Activity feed
+//
+// A feed of activity items. Within each section, there should be many
+// articles which are the feed items.
+```
 
 CSS rules that depend on specific HTML structures should describe those structures using `<element#id.class:pseudo>` notation. For example:
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -2,6 +2,13 @@
 
 KSS attempts to provide a methodology for writing maintainable, documented CSS within a team. Specifically, KSS is a documentation specification and style guide format. It is **not** a preprocessor, CSS framework, naming convention, or specificity guideline.
 
+However, there are several software projects that provide preprocessors that read and parse KSS-compliant documentation to produce full-blown style guides in HTML. Most of those implementations provide:
+
+1. a tool to generate a style guide by parsing CSS source files to find KSS docs, and
+2. a language-dependent API that represents the style guide as a data structure.
+
+This specification does not discuss those implementations.
+
 ## Purpose
 
 KSS is a set of guidelines to help you produce an HTML style guide tied to CSS documentation that is nice to read in plain text, yet structured enough to be automatically extracted and processed by a machine. It is designed with CSS preprocessors (such as SCSS or LESS) in mind, and flexible enough to accommodate a multitude of CSS frameworks (such as YUI, Blueprint or 960).

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # Knyle Style Sheets
 
-Inspired by [TomDoc](http://tomdoc.org), KSS attempts to provide a methodology for writing maintainable, documented CSS within a team. Specifically, KSS is a documentation specification and style guide format. It is **not** a preprocessor, CSS framework, naming convention, or specificity guideline.
+KSS attempts to provide a methodology for writing maintainable, documented CSS within a team. Specifically, KSS is a documentation specification and style guide format. It is **not** a preprocessor, CSS framework, naming convention, or specificity guideline.
 
 ## Purpose
 
@@ -10,7 +10,7 @@ KSS focuses on *how people work with CSS* — it does not define code structures
 
 ## Style Documentation
 
-Unlike TomDoc, not every CSS rule should be documented. You should document a rule declaration when the rule can accurately describe a visual UI element in the style guide. Each element should have one documentation block describing that particular UI element's various states.
+Not every CSS rule should be documented. You should document a rule declaration when the rule can accurately describe a visual UI element in the style guide. Each element should have one documentation block describing that particular UI element's various states.
 
 KSS documentation is hierarchical in nature — any documentation block at any point within the style guide hierarchy applies to the documentation blocks beneath that level. This means that documentation for 2.1 applies to documentation for 2.1.3.
 
@@ -203,3 +203,7 @@ This style guide is automatically generated from KSS documentation using the rub
 The actual templates generating the style guide just reference the Styleguide section and example HTML. The modified states are generated automatically. Refer to the README for more information on how to generate style guides using the KSS ruby library.
 
 Overall, keep in mind that style guides should adapt to the application they are referencing and be easy to maintain and as automatic as possible.
+
+### Acknowledgements
+
+KSS was inspired by [TomDoc](http://tomdoc.org).

--- a/SPEC.md
+++ b/SPEC.md
@@ -34,7 +34,7 @@ A button suitable for giving stars to someone.
 .stars-given:hover - Subtle hover highlight on top of stars-given styling.
 .disabled          - Dims the button to indicate it cannot be used.
 
-Styleguide 2.1.3.
+Styleguide 2.1.3
 */
 a.button.star{
   ...
@@ -57,7 +57,7 @@ When using a preprocessor that supports the functionality, use `//` to prefix yo
 // .stars-given:hover - Subtle hover highlight on top of stars-given styling.
 // .disabled          - Dims the button to indicate it cannot be used.
 //
-// Styleguide 2.1.3.
+// Styleguide 2.1.3
 a.button.star{
   ...
   &.star-given{

--- a/SPEC.md
+++ b/SPEC.md
@@ -36,13 +36,13 @@ A button suitable for giving stars to someone.
 
 Styleguide 2.1.3
 */
-.button.star {
+.star-button {
   ...
 }
-a.button.star.stars-given {
+.star-button.stars-given {
   ...
 }
-a.button.star.disabled {
+.star-button.disabled {
   ...
 }
 ```
@@ -58,7 +58,7 @@ When using a preprocessor that supports the functionality, use `//` to prefix yo
 // .disabled          - Dims the button to indicate it cannot be used.
 //
 // Styleguide 2.1.3
-a.button.star {
+.star-button {
   ...
   &.stars-given {
     ...

--- a/SPEC.md
+++ b/SPEC.md
@@ -138,15 +138,19 @@ If there is no example, then you must note that there is no reference.
 
 ## Preprocessor Helper Documentation
 
-If you use a CSS preprocessor like Sass or LESS, you should document all helper functions (sometimes called mixins).
+If you use a CSS preprocessor like Sass or LESS, you should document all helper code (like functions or mixins).
 
 ```scss
+// gradient($start, $end)
+//
 // Creates a linear gradient background, from top to bottom.
 //
 // $start - The color hex at the top.
 // $end   - The color hex at the bottom.
 //
 // Compatible in IE6+, Firefox 2+, Safari 4+.
+//
+// Styleguide sass.mixins.gradient
 @mixin gradient($start, $end) {
   ...
 }

--- a/SPEC.md
+++ b/SPEC.md
@@ -11,7 +11,7 @@ This specification does not discuss those implementations.
 
 ## Purpose
 
-KSS is a set of guidelines to help you produce an HTML style guide tied to CSS documentation that is nice to read in plain text, yet structured enough to be automatically extracted and processed by a machine. It is designed with CSS preprocessors (such as SCSS or LESS) in mind, and flexible enough to accommodate a multitude of CSS frameworks (such as YUI, Blueprint or 960).
+KSS is a set of guidelines to help you produce an HTML style guide tied to CSS documentation that is nice to read in plain text, yet structured enough to be automatically extracted and processed by a machine. It is designed with CSS preprocessors (such as SCSS or LESS) in mind, and flexible enough to accommodate a multitude of CSS frameworks (such as Bootstrap or Foundation).
 
 KSS focuses on *how people work with CSS* — it does not define code structures, naming conventions, or methods for abstraction. It is important to understand that the style guide format and documentation format are intrinsically tied to one another.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -36,13 +36,13 @@ A button suitable for giving stars to someone.
 
 Styleguide 2.1.3
 */
-a.button.star{
+.button.star {
   ...
 }
-a.button.star.stars-given{
+a.button.star.stars-given {
   ...
 }
-a.button.star.disabled{
+a.button.star.disabled {
   ...
 }
 ```
@@ -58,12 +58,12 @@ When using a preprocessor that supports the functionality, use `//` to prefix yo
 // .disabled          - Dims the button to indicate it cannot be used.
 //
 // Styleguide 2.1.3
-a.button.star{
+a.button.star {
   ...
-  &.star-given{
+  &.star-given {
     ...
   }
-  &.disabled{
+  &.disabled {
     ...
   }
 }
@@ -147,7 +147,7 @@ If you use a CSS preprocessor like SCSS or LESS, you should document all helper 
 // $end   - The color hex at the bottom.
 //
 // Compatible in IE6+, Firefox 2+, Safari 4+.
-@mixin gradient($start, $end){
+@mixin gradient($start, $end) {
   ...
 }
 ```

--- a/SPEC.md
+++ b/SPEC.md
@@ -60,7 +60,7 @@ When using a preprocessor that supports the functionality, use `//` to prefix yo
 // Styleguide 2.1.3
 a.button.star {
   ...
-  &.star-given {
+  &.stars-given {
     ...
   }
   &.disabled {

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,18 +1,18 @@
 # Knyle Style Sheets
 
-Inspired by [TomDoc](http://tomdoc.org), KSS attempts to provide a methodology for writing maintainable, documented CSS within a team. Specifically, KSS is a documentation specification and styleguide format. It is **not** a preprocessor, CSS framework, naming convention, or specificity guideline.
+Inspired by [TomDoc](http://tomdoc.org), KSS attempts to provide a methodology for writing maintainable, documented CSS within a team. Specifically, KSS is a documentation specification and style guide format. It is **not** a preprocessor, CSS framework, naming convention, or specificity guideline.
 
 ## Purpose
 
-KSS is a set of guidelines to help you produce an HTML styleguide tied to CSS documentation that is nice to read in plain text, yet structured enough to be automatically extracted and processed by a machine. It is designed with CSS preprocessors (such as SCSS or LESS) in mind, and flexible enough to accommodate a multitude of CSS frameworks (such as YUI, Blueprint or 960).
+KSS is a set of guidelines to help you produce an HTML style guide tied to CSS documentation that is nice to read in plain text, yet structured enough to be automatically extracted and processed by a machine. It is designed with CSS preprocessors (such as SCSS or LESS) in mind, and flexible enough to accommodate a multitude of CSS frameworks (such as YUI, Blueprint or 960).
 
-KSS focuses on *how people work with CSS* — it does not define code structures, naming conventions, or methods for abstraction. It is important to understand that the styleguide format and documentation format are intrinsically tied to one another.
+KSS focuses on *how people work with CSS* — it does not define code structures, naming conventions, or methods for abstraction. It is important to understand that the style guide format and documentation format are intrinsically tied to one another.
 
 ## Style Documentation
 
-Unlike TomDoc, not every CSS rule should be documented. You should document a rule declaration when the rule can accurately describe a visual UI element in the styleguide. Each element should have one documentation block describing that particular UI element's various states.
+Unlike TomDoc, not every CSS rule should be documented. You should document a rule declaration when the rule can accurately describe a visual UI element in the style guide. Each element should have one documentation block describing that particular UI element's various states.
 
-KSS documentation is hierarchical in nature — any documentation blocks at any point within the styleguide hierarchy apply to the documentation blocks beneath that level. This means that documentation for 2.1 applies to documentation for 2.1.3.
+KSS documentation is hierarchical in nature — any documentation blocks at any point within the style guide hierarchy apply to the documentation blocks beneath that level. This means that documentation for 2.1 applies to documentation for 2.1.3.
 
 ### Format
 
@@ -62,7 +62,7 @@ a.button.star{
 }
 ```
 
-Each KSS documentation block consists of three parts: a description of what the element does or looks like, a list of modifier classes or pseudo-classes and how they modify the element, and a reference to the element's position in the styleguide.
+Each KSS documentation block consists of three parts: a description of what the element does or looks like, a list of modifier classes or pseudo-classes and how they modify the element, and a reference to the element's position in the style guide.
 
 ### The description section
 
@@ -103,13 +103,13 @@ If the UI element you are documenting has multiple states or styles depending on
 
 ### The styleguide section
 
-If the UI element you are documenting has an example in the styleguide, you should reference it using the "Styleguide [ref]" syntax.
+If the UI element you are documenting has an example in the style guide, you should reference it using the "Styleguide [ref]" syntax.
 
 ```scss
 // Styleguide 2.1.3.
 ```
 
-References can be integer sections separated by periods. Each period denotes a hierarchy of the styleguide. Styleguide references can point to entire sections, a portion of the section, or a specific example.
+References can be integer sections separated by periods. Each period denotes a hierarchy of the style guide. Style guide references can point to entire sections, a portion of the section, or a specific example.
 
 References may also be period seperated word keys.  Leading words denote hierarchy.
 
@@ -170,13 +170,13 @@ If you do not know the compatibility, you should state as such.
 // Compatibility untested.
 ```
 
-## Styleguide
+## Style guide
 
-In order to fully take advantage of KSS, you should create a living styleguide. A living styleguide is a *part of your application* and includes all of the CSS, Javascript, and layout the rest of your application does.
+In order to fully take advantage of KSS, you should create a living style guide. A living style guide is a *part of your application* and includes all of the CSS, Javascript, and layout the rest of your application does.
 
 ### Organization
 
-The styleguide should be organized by numbered sections. These sections can go as deep as you like. Every element should have a numbered section to refer to. For example:
+The style guide should be organized by numbered sections. These sections can go as deep as you like. Every element should have a numbered section to refer to. For example:
 
     1. Buttons
       1.1 Form Buttons
@@ -196,10 +196,10 @@ The goal here is to create an organizational structure that is flexible, but  ri
 
 ### Example
 
-This styleguide is automatically generated from KSS documentation using the ruby library.
+This style guide is automatically generated from KSS documentation using the ruby library.
 
 ![](http://share.kyleneath.com/captures/Styleguide_-_GitHub_Team-20111202-160539.png)
 
-The actual templates generating the styleguide just reference the Styleguide section and example HTML. The modified states are generated automatically. Refer to the README for more information on how to generate styleguides using the KSS ruby library.
+The actual templates generating the style guide just reference the Styleguide section and example HTML. The modified states are generated automatically. Refer to the README for more information on how to generate style guides using the KSS ruby library.
 
-Overall, keep in mind that styleguides should adapt to the application they are referencing and be easy to maintain and as automatic as possible.
+Overall, keep in mind that style guides should adapt to the application they are referencing and be easy to maintain and as automatic as possible.

--- a/SPEC.md
+++ b/SPEC.md
@@ -72,7 +72,7 @@ CSS rules that depend on specific HTML structures should describe those structur
 
 ```scss
 // A feed of activity items. Within each <section.feed>, there should be many
-// <article>s which are the  feed items.
+// <article>s which are the feed items.
 ```
 
 To describe the status of a set of rules, you should prefix the description with **Experimental** or **Deprecated**.
@@ -111,7 +111,7 @@ If the UI element you are documenting has an example in the style guide, you sho
 
 References can be integer sections separated by periods. Each period denotes a hierarchy of the style guide. Style guide references can point to entire sections, a portion of the section, or a specific example.
 
-References may also be period seperated word keys.  Leading words denote hierarchy.
+References may also be period seperated word keys. Leading words denote hierarchy.
 
 ```scss
 // Styleguide Forms.Checkboxes.
@@ -145,7 +145,7 @@ If you use a CSS preprocessor like SCSS or LESS, you should document all helper 
 }
 ```
 
-Each documentation block should have a description section, parameters section, and compatibility section.  The description section follows the same guidelines as style documentation.
+Each documentation block should have a description section, parameters section, and compatibility section. The description section follows the same guidelines as style documentation.
 
 ### The parameters section
 
@@ -192,7 +192,7 @@ The style guide should be organized by numbered sections. These sections can go 
       4.1 Number tables
       4.2 Diagram tables
 
-The goal here is to create an organizational structure that is flexible, but  rigid enough to be machine processed and referenced inside of documentation.
+The goal here is to create an organizational structure that is flexible, but rigid enough to be machine processed and referenced inside of documentation.
 
 ### Example
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -11,7 +11,7 @@ This specification does not discuss those implementations.
 
 ## Purpose
 
-KSS is a set of guidelines to help you produce an HTML style guide tied to CSS documentation that is nice to read in plain text, yet structured enough to be automatically extracted and processed by a machine. It is designed with CSS preprocessors (such as SCSS or LESS) in mind, and flexible enough to accommodate a multitude of CSS frameworks (such as Bootstrap or Foundation).
+KSS is a set of guidelines to help you produce an HTML style guide tied to CSS documentation that is nice to read in plain text, yet structured enough to be automatically extracted and processed by a machine. It is designed with CSS preprocessors (such as Sass or LESS) in mind, and flexible enough to accommodate a multitude of CSS frameworks (such as Bootstrap or Foundation).
 
 KSS focuses on *how people work with CSS* — it does not define code structures, naming conventions, or methods for abstraction. It is important to understand that the style guide format and documentation format are intrinsically tied to one another.
 
@@ -47,7 +47,7 @@ a.button.star.disabled {
 }
 ```
 
-When using a preprocessor that supports the functionality, use `//` to prefix your comment sections (SCSS example):
+When using a preprocessor that supports the functionality, use `//` to prefix your comment sections (Sass example):
 
 ```scss
 // A button suitable for giving stars to someone.
@@ -138,7 +138,7 @@ If there is no example, then you must note that there is no reference.
 
 ## Preprocessor Helper Documentation
 
-If you use a CSS preprocessor like SCSS or LESS, you should document all helper functions (sometimes called mixins).
+If you use a CSS preprocessor like Sass or LESS, you should document all helper functions (sometimes called mixins).
 
 ```scss
 // Creates a linear gradient background, from top to bottom.


### PR DESCRIPTION
I broke this PR into several little commits so you can easily tell me which changes are unacceptable or need work. I tried to put non-controversial changes first.

Notes:
- 25556f3 TomDoc means nothing to non-Ruby devs. And putting it *first* in the spec makes it seem like you *should* know what it is before you read the KSS spec.
- 27c5e1a The spec is pretty emphatic about KSS not being a preprocessor. That's fine, but at least add a note that there *are* preprocessors available that can parse KSS and generate style guides.
- be71b3a YUI, Blueprint and 960? Party like it's 2006!
- e4216f4 The `a.button.star` selector is complex. Simplifying it will make the examples clearer. Especially when trying to figure out what is the modifier and what is the default style.
- e1b6a8e For the longest time, I couldn't figure out how to make kss-node generate docs for CSS preprocessor helpers. And its because this example was missing parts.
- 37245c2 The Ruby implementation uses the first paragraph of the description as a heading for the style guide section. So does kss-node. Living style guides just don't work without a heading for each section. Can we make this explicit in the spec?