### PR TITLE
Raises an error if styleguide section comment misses section definition

### DIFF
--- a/lib/kss/section.rb
+++ b/lib/kss/section.rb
@@ -1,4 +1,8 @@
 module Kss
+
+  class SectionNotDefinedError < StandardError
+  end
+
   # Public: Represents a styleguide section. Each section describes one UI
   # element. A Section can be thought of as the collection of the description,
   # modifiers, and styleguide reference.
@@ -35,7 +39,14 @@ module Kss
       return @section unless @section.nil?
 
       cleaned  = section_comment.strip.sub(/\.$/, '') # Kill trailing period
-      @section = cleaned.match(/Styleguide (.+)/i)[1]
+      match_result = cleaned.match(/Styleguide (.+)/i)
+
+      if match_result
+        @section = match_result[1]
+      else
+        raise SectionNotDefinedError.new,
+          'No section string found in comment block.'
+      end
 
       @section
     end

--- a/test/section_test.rb
+++ b/test/section_test.rb
@@ -39,6 +39,12 @@ comment
     assert_equal '2.1.1', @section.section
   end
 
+  test "raises an error if styleguide reference is not set" do
+    assert_raises Kss::SectionNotDefinedError do
+      Kss::Section.new('', 'example.css').section
+    end
+  end
+
   test "parses word phrases as styleguide references" do
     @comment_text.gsub!('2.1.1', 'Buttons - Truly Lime')
     section = Kss::Section.new(@comment_text, 'example.css')


### PR DESCRIPTION
Prior to this patch, if one tried to access a section (name) of a parsed KSS section comment that misses the section name definition, a `NoMethodError: undefined method `[]' for nil:NilClass` was thrown because the code assumed the Regex for finding the section name always succeeded.

To handle this error of a missing or wrongly formatted section name catching the very generic `NoMethodError` is not specific enough. I therefore introduced a `SectionNotDefinedError` that can be catched instead.
