### PR TITLE
Updates Reference to KSS-PHP Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,5 +117,5 @@ I apologize on behalf of the Ruby community for this, it's embarrassing and disa
 
 ## Implementations
 
-The KSS specification has also been implemented in [Python](https://github.com/seanbrant/pykss), [Node.js](https://github.com/kss-node/kss-node), [PHP](https://github.com/scaninc/kss-php) and [Java] (https://github.com/revbingo/kss-java)
+The KSS specification has also been implemented in [Python](https://github.com/seanbrant/pykss), [Node.js](https://github.com/kss-node/kss-node), [PHP](https://github.com/kss-php/kss-php) and [Java] (https://github.com/revbingo/kss-java)
 


### PR DESCRIPTION
The URL for KSS-PHP has changed. This corrects the readme to point to the correct URL.